### PR TITLE
Add functionality to remove bucket

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class Client {
     data.Buckets.forEach(function(bucket) {
       if (bucket.Name === this.bucketName) {
         this.bucketExists = true;
-        this.serverless.cli.log(`Bucket ${this.bucketName} already exists`);
+        this.serverless.cli.log(`Bucket ${this.bucketName} exists`);
       }
     }.bind(this));
   }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ class Client {
             lifecycleEvents:[
               'deploy'
             ]
+          },
+          remove: {
+            usage: 'Removes deployed files and bucket',
+            lifecycleEvents: [
+              'remove'
+            ]
           }
         }
       }
@@ -42,8 +48,81 @@ class Client {
       'client:deploy:deploy': () => {
         this._validateAndPrepare()
           .then(this._processDeployment.bind(this));
+      },
+      'client:remove:remove': () => {
+        this._removeDeployedResources();
       }
     };
+  }
+
+  // Shared functions
+
+  listBuckets(data) {
+    return this.aws.request('S3', 'listBuckets', {}, this.stage, this.region).bind(this);
+  }
+
+  findBucket(data) {
+    data.Buckets.forEach(function(bucket) {
+      if (bucket.Name === this.bucketName) {
+        this.bucketExists = true;
+        this.serverless.cli.log(`Bucket ${this.bucketName} already exists`);
+      }
+    }.bind(this));
+  }
+
+  listObjectsInBucket() {
+    if (!this.bucketExists) return BbPromise.resolve();
+
+    this.serverless.cli.log(`Listing objects in bucket ${this.bucketName}...`);
+
+    let params = {
+      Bucket: this.bucketName
+    };
+
+    return this.aws.request('S3', 'listObjectsV2', params, this.stage, this.region);
+  }
+
+  deleteObjectsFromBucket(data) {
+    if (!this.bucketExists) return BbPromise.resolve();
+
+    this.serverless.cli.log(`Deleting all objects from bucket ${this.bucketName}...`);
+
+    if (!data.Contents[0]) {
+      return BbPromise.resolve();
+    } else {
+      let Objects = _.map(data.Contents, function (content) {
+        return _.pick(content, 'Key');
+      });
+
+      let params = {
+        Bucket: this.bucketName,
+        Delete: { Objects: Objects }
+      };
+
+      return this.aws.request('S3', 'deleteObjects', params, this.stage, this.region);
+    }
+  }
+
+  // Hook handlers
+
+  _removeDeployedResources() {
+    this.bucketName = this.serverless.service.custom.client.bucketName;
+    this.serverless.cli.log(`Preparing to remove bucket ${this.bucketName}`);
+
+    let params = {
+      Bucket: this.bucketName
+    };
+
+    function deleteBucket() {
+      this.serverless.cli.log(`Removing bucket ${this.bucketName}...`);
+      return this.aws.request('S3', 'deleteBucket', params, this.stage, this.region);
+    }
+
+    return this.listBuckets()
+      .then(this.findBucket)
+      .then(this.listObjectsInBucket)
+      .then(this.deleteObjectsFromBucket)
+      .then(deleteBucket)
   }
 
   _validateAndPrepare() {
@@ -71,49 +150,6 @@ class Client {
 
   _processDeployment() {
     this.serverless.cli.log('Deploying client to stage "' + this.stage + '" in region "' + this.region + '"...');
-
-
-    function listBuckets(data) {
-      data.Buckets.forEach(function(bucket) {
-        if (bucket.Name === this.bucketName) {
-          this.bucketExists = true;
-          this.serverless.cli.log(`Bucket ${this.bucketName} already exists`);
-        }
-      }.bind(this));
-    }
-
-    function listObjectsInBucket() {
-      if (!this.bucketExists) return BbPromise.resolve();
-
-      this.serverless.cli.log(`Listing objects in bucket ${this.bucketName}...`);
-
-      let params = {
-        Bucket: this.bucketName
-      };
-
-      return this.aws.request('S3', 'listObjectsV2', params, this.stage, this.region);
-    }
-
-    function deleteObjectsFromBucket(data) {
-      if (!this.bucketExists) return BbPromise.resolve();
-
-      this.serverless.cli.log(`Deleting all objects from bucket ${this.bucketName}...`);
-
-      if (!data.Contents[0]) {
-        return BbPromise.resolve();
-      } else {
-        let Objects = _.map(data.Contents, function (content) {
-          return _.pick(content, 'Key');
-        });
-
-        let params = {
-          Bucket: this.bucketName,
-          Delete: { Objects: Objects }
-        };
-
-        return this.aws.request('S3', 'deleteObjects', params, this.stage, this.region);
-      }
-    }
 
     function createBucket() {
       if (this.bucketExists) return BbPromise.resolve();
@@ -211,11 +247,10 @@ class Client {
       return this.aws.request('S3', 'putBucketCors', params, this.stage, this.region);
     }
 
-    return this.aws.request('S3', 'listBuckets', {}, this.stage, this.region)
-      .bind(this)
-      .then(listBuckets)
-      .then(listObjectsInBucket)
-      .then(deleteObjectsFromBucket)
+    return this.listBuckets()
+      .then(this.findBucket)
+      .then(this.listObjectsInBucket)
+      .then(this.deleteObjectsFromBucket)
       .then(createBucket)
       .then(configureBucket)
       .then(configurePolicyForBucket)


### PR DESCRIPTION
References this issue: https://github.com/fernando-mc/serverless-finch/issues/9

Adds the command `serverless client remove` which empties the bucket and removes it. Some notes:

1) I refactored to make use of the functions that finds and empties the bucket from the `deploy` command. Im not overly familiar with the Class-style syntax in JS these days, so let me know what you think
2) I also added an arbitary 3 second delay to the remove process, as its clearly a very destructive process! Not sure if thats overkill though, thoughts?

<img width="781" alt="screen shot 2017-10-20 at 10 51 50" src="https://user-images.githubusercontent.com/425213/31816046-ab4d0014-b586-11e7-88b0-b60e93f73d98.png">
