### PR TITLE
Fix GH-17 variables do not get expanded

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ const regionToUrlRootMap = region => ({
 class Client {
   constructor(serverless, options){
     this.serverless = serverless;
-    this.stage = options.stage || _.get(serverless, 'service.provider.stage')
-    this.region = options.region || _.get(serverless, 'service.provider.region');
     this.provider = 'aws';
     this.aws = this.serverless.getProvider(this.provider);
 
@@ -65,6 +63,8 @@ class Client {
       },
 
       'client:deploy:deploy': () => {
+        this.stage = options.stage || _.get(serverless, 'service.provider.stage')
+        this.region = options.region || _.get(serverless, 'service.provider.region');
         this._validateAndPrepare()
           .then(this._processDeployment.bind(this));
       },


### PR DESCRIPTION
These point to the solution:

* https://forum.serverless.com/t/serverless-plugin-resolving-variable-references/2233/2
* https://github.com/serverless/serverless/pull/3911/files

TL;DR: dschep wrote "Serverless changed it’s behavior a few releases
ago. That variable substitution is not called by the time plugin
constructors get called. Unless you actually need it then, just access
it in your lifecycle hooks, it’ should be resolved by then."