### PR TITLE
Implement Feature Request: Add custom fields to define index and error documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ custom:
   client:
     bucketName: unique-s3-bucketname-for-your-website-files
     distributionFolder: client/dist # (Optional) The location of your website. This defaults to client/dist
+    indexDocument: index.html # (Optional) The location of your index document. Defaults to index.html
+    errorDocument: error.html # (Optional) The location of your error document. Defaults to error.html
+    spa: false # (Optional) Set this to true to redirect all errors to the index document
 ```
 
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.
+
+* **Warning:** If the 'spa' option is set, the errorDocument setting will be ignored.
 
 
 **Third**, Create a website folder in the root directory of your Serverless project. This is where your distribution-ready website should live. By default the plugin expects the files to live in a folder called `client/dist`. But this is configurable with the `distributionFolder` option (see the example yaml configuration above).
@@ -76,5 +81,6 @@ serverless client remove
 - [amsross](https://github.com/amsross)
 - [pradel](https://github.com/pradel)
 - [daguix](https://github.com/daguix)
+- [evanseeds](https://github.com/evanseeds)
 
 Forked from the [**serverless-client-s3**](https://github.com/serverless/serverless-client-s3/)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ custom:
     distributionFolder: client/dist # (Optional) The location of your website. This defaults to client/dist
     indexDocument: index.html # (Optional) The location of your index document. Defaults to index.html
     errorDocument: error.html # (Optional) The location of your error document. Defaults to error.html
-    spa: false # (Optional) Set this to true to redirect all errors to the index document
+    spa: false # (Optional) Set this for single-page applications to redirect all errors to the index document
 ```
 
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,9 @@ custom:
     distributionFolder: client/dist # (Optional) The location of your website. This defaults to client/dist
     indexDocument: index.html # (Optional) The location of your index document. Defaults to index.html
     errorDocument: error.html # (Optional) The location of your error document. Defaults to error.html
-    spa: false # (Optional) Set this for single-page applications to redirect all errors to the index document
 ```
 
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.
-
-* **Warning:** If the 'spa' option is set, the errorDocument setting will be ignored.
 
 
 **Third**, Create a website folder in the root directory of your Serverless project. This is where your distribution-ready website should live. By default the plugin expects the files to live in a folder called `client/dist`. But this is configurable with the `distributionFolder` option (see the example yaml configuration above).

--- a/index.js
+++ b/index.js
@@ -186,13 +186,8 @@ class Client {
     function configureBucket() {
       this.serverless.cli.log(`Configuring website bucket ${this.bucketName}...`);
 
-      let indexDoc, errorDoc;
-      if (this.serverless.service.custom.spa) {
-        indexDoc = errorDoc = this.serverless.service.custom.client.indexDocument || 'index.html'
-      } else {
-        indexdoc = this.serverless.service.custom.client.indexDocument || 'index.html'
-        errorDoc = this.serverless.service.custom.client.errorDocument || 'error.html'
-      }
+      const indexDoc = this.serverless.service.custom.client.indexDocument || 'index.html'
+      const errorDoc = this.serverless.service.custom.client.errorDocument || 'error.html'
 
       let params = {
         Bucket: this.bucketName,

--- a/index.js
+++ b/index.js
@@ -186,11 +186,19 @@ class Client {
     function configureBucket() {
       this.serverless.cli.log(`Configuring website bucket ${this.bucketName}...`);
 
+      let indexDoc, errorDoc;
+      if (this.serverless.service.custom.spa) {
+        indexDoc = errorDoc = this.serverless.service.custom.client.indexDocument || 'index.html'
+      } else {
+        indexdoc = this.serverless.service.custom.client.indexDocument || 'index.html'
+        errorDoc = this.serverless.service.custom.client.errorDocument || 'error.html'
+      }
+
       let params = {
         Bucket: this.bucketName,
         WebsiteConfiguration: {
-          IndexDocument: { Suffix: 'index.html' },
-          ErrorDocument: { Key: 'error.html' }
+          IndexDocument: { Suffix: indexDoc },
+          ErrorDocument: { Key: errorDoc }
         }
       };
 


### PR DESCRIPTION
Added three .yml options: 'indexDocument' and 'errorDocument', which allow customizing the s3 bucket option for each, and 'spa', which automatically sets the errorDocument to be the indexDocument, overriding the errorDocument .yml setting if both are set.

This implements the issue at https://github.com/fernando-mc/serverless-finch/issues/16