### PR TITLE
Added configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ custom:
   client:
     bucketName: unique-s3-bucketname-for-your-website-files
     distributionFolder: client/dist # (Optional) The location of your website. This defaults to client/dist
+    configurationScript: client/config.js # (Optional) The location of a config script. Perform any needed configuration logic.
     indexDocument: index.html # (Optional) The name of your index document inside your distributionFolder. Defaults to index.html
     errorDocument: error.html # (Optional) The name of your error document inside your distributionFolder. Defaults to error.html
 ```
@@ -51,6 +52,23 @@ serverless client deploy [--stage $STAGE] [--region $REGION]
 
 The plugin should output the location of your newly deployed static site to the console.
 
+
+```
+serverless client config
+```
+Optionally perform any needed pre-deployment configuration logic, such as writing configuration specific settings
+to your static assets. This is useful when deploying a full-stack application for example. The plugin will
+pass the serverless object into the defined configuration file.
+
+example configuration file.
+
+```javascript
+module.exports = function(serverless){
+  ...someLogicHere
+}
+```
+
+
 If later on you want to take down the website you can use:
 
 ```
@@ -70,7 +88,7 @@ serverless client remove
 - Fixed an issue with resolving serverless variables ([Pull 18](https://github.com/fernando-mc/serverless-finch/pull/18) - [shentonfreude](https://github.com/shentonfreude))
 
 ### v1.2.*
-- Added the `remove` option to tear down what you deploy. ([Pull 10](https://github.com/fernando-mc/serverless-finch/pull/10) thanks to [redroot](https://github.com/redroot)) 
+- Added the `remove` option to tear down what you deploy. ([Pull 10](https://github.com/fernando-mc/serverless-finch/pull/10) thanks to [redroot](https://github.com/redroot))
 - Fixed automated builds for the project (no functional differences)
 
 ## Maintainers

--- a/index.js
+++ b/index.js
@@ -46,6 +46,12 @@ class Client {
               'deploy'
             ]
           },
+          config: {
+            usage: 'Configure client by executing config script.',
+            lifecycleEvents:[
+              'config'
+            ]
+          },
           remove: {
             usage: 'Removes deployed files and bucket',
             lifecycleEvents: [
@@ -60,6 +66,10 @@ class Client {
     this.hooks = {
       'client:client': () => {
         this.serverless.cli.log(this.commands.client.usage);
+      },
+
+      'client:config:config': () => {
+        this._configureClient();
       },
 
       'client:deploy:deploy': () => {
@@ -123,6 +133,18 @@ class Client {
   }
 
   // Hook handlers
+
+  _configureClient(){
+    var configurationScript = _.get(this.serverless, 'service.custom.client.configurationScript');
+    var configPath = path.join(this.serverless.config.servicePath, configurationScript);
+    if(configurationScript !== null && configurationScript !== undefined){
+      this.serverless.cli.log(`Executing config script ${configurationScript}`);
+      var config = require(`${configPath}`);
+      config(this.serverless);
+    }else{
+      this.serverless.cli.log('No configutation script defined.');
+    }
+  }
 
   _removeDeployedResources() {
     this.bucketName = this.serverless.service.custom.client.bucketName;


### PR DESCRIPTION
Added a configuration option that will execute a degined configuration
script. This will pass the serverless object into the configuration
script allowing user to perform any needed pre-deployment configuration
tasks needed. This is specifically useful with full-stack apps for
example, using the serverless object to gain access to already deployed
resources/api endpoints.

I had specific requirements to deploy some lambda functions as well as a client, adding this was the only good option I could come up without, outside of writing a shell script. I am still new with the serverless framework so please feel free to point out any holes here.