### PR TITLE
Fix validator bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,16 @@ custom:
     ...
     objectHeaders:
       ALL_OBJECTS:
-        - headerName: [header-name]
-          headerValue: [header-value]
+        - name: [header-name]
+          value: [header-value]
         ...
       specific-directory/:
-        - headerName: [header-name]
-          headerValue: [header-value]
+        - name: [header-name]
+          value: [header-value]
         ...
       specific-file.ext:
-        - headerName: [header-name]
-          headerValue: [header-value]
+        - name: [header-name]
+          value: [header-value]
         ...
       ... [more file- or folder-specific rules]
     ...
@@ -151,7 +151,7 @@ custom:
 
 Use the `objectHeaders` option to set HTTP response headers be sent to clients requesting uploaded files from your website. 
 
-Headers may be specified globally for all files in the bucket by adding a `headerName`, `headerValue` pair to the `ALL_OBJECTS` property of the `objectHeaders` option. They may also be specified for specific folders or files within your site by specifying properties with names like `specific-directory/` (trailing slash required to indicate folder) or `specific-file.ext`, where the folder and/or file paths are relative to `distributionFolder`. 
+Headers may be specified globally for all files in the bucket by adding a `name`, `value` pair to the `ALL_OBJECTS` property of the `objectHeaders` option. They may also be specified for specific folders or files within your site by specifying properties with names like `specific-directory/` (trailing slash required to indicate folder) or `specific-file.ext`, where the folder and/or file paths are relative to `distributionFolder`. 
 
 Headers with more specificity will take precedence over more general ones. For instance, if 'Cache-Control' was set to 'max-age=100' in `ALL_OBJECTS` and to 'max-age=500' in `my/folder/`, the files in `my/folder/` would get a header of 'Cache-Control: max-age=500'.
 

--- a/index.js
+++ b/index.js
@@ -51,19 +51,22 @@ class Client {
   }
 
   _validateConfig() {
-    const validationError = validateClient(this.serverless, this.options);
-    if (validationError) {
-      return BbPromise.reject(new this.error(validationError));
+    try {
+      validateClient(this.serverless, this.options);
+    } catch (e) {
+      return BbPromise.reject(new this.error(e));
     }
+    return BbPromise.resolve();
   }
 
   _removeDeployedResources() {
-    this._validateConfig();
+    let bucketName;
 
-    const bucketName = this.options.bucketName;
-
-    return new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`)
-      .run()
+    return this._validateConfig()
+      .then(() => {
+        bucketName = this.options.bucketName;
+        return new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
+      })
       .then(goOn => {
         if (goOn) {
           this.serverless.cli.log(`Looking for bucket...`);
@@ -95,49 +98,58 @@ class Client {
   }
 
   _processDeployment() {
-    this._validateConfig();
+    let region,
+      distributionFolder,
+      clientPath,
+      bucketName,
+      headerSpec,
+      indexDoc,
+      errorDoc,
+      redirectAllRequestsTo,
+      routingRules;
 
-    // region is set based on the following order of precedence:
-    // If specified, the CLI option is used
-    // If region is not specified via the CLI, we use the region option specified
-    //   under custom/client in serverless.yml
-    // Otherwise, use the Serverless region specified under provider in serverless.yml
-    const region =
-      this.cliOptions.region ||
-      this.options.region ||
-      _.get(this.serverless, 'service.provider.region');
+    return this._validateConfig()
+      .then(() => {
+        // region is set based on the following order of precedence:
+        // If specified, the CLI option is used
+        // If region is not specified via the CLI, we use the region option specified
+        //   under custom/client in serverless.yml
+        // Otherwise, use the Serverless region specified under provider in serverless.yml
+        region =
+          this.cliOptions.region ||
+          this.options.region ||
+          _.get(this.serverless, 'service.provider.region');
 
-    const distributionFolder = this.options.distributionFolder || path.join('client/dist');
-    const clientPath = path.join(this.serverless.config.servicePath, distributionFolder);
-    const bucketName = this.options.bucketName;
-    const headerSpec = this.options.objectHeaders;
-    const indexDoc = this.options.indexDocument || index.html;
-    const errorDoc = this.options.errorDocument || error.html;
-    const redirectAllRequestsTo = this.options.redirectAllRequestsTo || null;
-    const routingRules = this.options.routingRules || null;
+        distributionFolder = this.options.distributionFolder || path.join('client/dist');
+        clientPath = path.join(this.serverless.config.servicePath, distributionFolder);
+        bucketName = this.options.bucketName;
+        headerSpec = this.options.objectHeaders;
+        indexDoc = this.options.indexDocument || index.html;
+        errorDoc = this.options.errorDocument || error.html;
+        redirectAllRequestsTo = this.options.redirectAllRequestsTo || null;
+        routingRules = this.options.routingRules || null;
 
-    const deployDescribe = ['This deployment will:'];
+        const deployDescribe = ['This deployment will:'];
 
-    if (this.cliOptions['delete-contents']) {
-      deployDescribe.push(`- Remove all existing files from bucket '${bucketName}'`);
-    }
-    deployDescribe.push(
-      `- Upload all files from '${distributionFolder}' to bucket '${bucketName}'`
-    );
-    if (this.cliOptions['config-change'] !== false) {
-      deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' configuration`);
-    }
-    if (this.cliOptions['policy-change'] !== false) {
-      deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' bucket policy`);
-    }
-    if (this.cliOptions['cors-change'] !== false) {
-      deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' CORS policy`);
-    }
+        if (this.cliOptions['delete-contents']) {
+          deployDescribe.push(`- Remove all existing files from bucket '${bucketName}'`);
+        }
+        deployDescribe.push(
+          `- Upload all files from '${distributionFolder}' to bucket '${bucketName}'`
+        );
+        if (this.cliOptions['config-change'] !== false) {
+          deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' configuration`);
+        }
+        if (this.cliOptions['policy-change'] !== false) {
+          deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' bucket policy`);
+        }
+        if (this.cliOptions['cors-change'] !== false) {
+          deployDescribe.push(`- Set (and overwrite) bucket '${bucketName}' CORS policy`);
+        }
 
-    deployDescribe.forEach(m => this.serverless.cli.log(m));
-
-    return new Confirm(`Do you want to proceed?`)
-      .run()
+        deployDescribe.forEach(m => this.serverless.cli.log(m));
+        return new Confirm(`Do you want to proceed?`).run();
+      })
       .then(goOn => {
         if (goOn) {
           this.serverless.cli.log(`Looking for bucket...`);

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class Client {
     try {
       validateClient(this.serverless, this.options);
     } catch (e) {
-      return BbPromise.reject(new this.error(e));
+      return BbPromise.reject(`Serverless Finch configuration errors:\n- ${e.join('\n- ')}`);
     }
     return BbPromise.resolve();
   }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -16,38 +16,32 @@ function validateClient(serverless, options) {
   const distributionFolder = options.distributionFolder || path.join('client/dist');
   const clientPath = path.join(serverless.config.servicePath, distributionFolder);
   if (!serverless.utils.dirExistsSync(clientPath)) {
-    return `Could not find '${clientPath}' folder in your project root`;
+    throw `Could not find '${clientPath}' folder in your project root`;
   }
 
   // bucketName must be a string
   if (!is.string(options.bucketName)) {
-    return 'Please specify a bucket name for the client in serverless.yml';
+    throw 'Please specify a bucket name for the client in serverless.yml';
   }
 
   // check header options
   if (options.objectHeaders) {
     if (!is.object(options.objectHeaders)) {
-      return 'objectHeaders must be an object';
+      throw 'objectHeaders must be an object';
     }
 
     Object.keys(options.objectHeaders).forEach(p => {
       if (!is.array(options.objectHeaders[p])) {
-        return 'Each member of objectHeaders must be an array';
+        throw 'Each member of objectHeaders must be an array';
       }
 
-      Object.keys(options.objectHeaders[p]).forEach(h => {
-        if (
-          !is.existy(options.objectHeaders[p][h].name) ||
-          !is.string(options.objectHeaders[p][h].name)
-        ) {
-          return `Each object header must have a (string) 'name' attribute`;
+      options.objectHeaders[p].forEach(h => {
+        if (!(is.existy(h.name) && is.string(h.name))) {
+          throw `Each object header must have a (string) 'name' attribute`;
         }
 
-        if (
-          !is.existy(options.objectHeaders[p][h].value) ||
-          !is.string(options.objectHeaders[p][h].value)
-        ) {
-          return `Each object header must have a (string) 'value' attribute`;
+        if (!(is.existy(h.value) && is.string(h.value))) {
+          throw `Each object header must have a (string) 'value' attribute`;
         }
       });
     });
@@ -60,46 +54,46 @@ function validateClient(serverless, options) {
   if (options.redirectAllRequestsTo) {
     const clientConfigOptions = Object.keys(options);
     if (is.inArray('indexDocument', clientConfigOptions)) {
-      return 'indexDocument cannot be specified with redirectAllRequestsTo';
+      throw 'indexDocument cannot be specified with redirectAllRequestsTo';
     }
 
     if (is.inArray('errorDocument', clientConfigOptions)) {
-      return 'errorDocument cannot be specified with redirectAllRequestsTo';
+      throw 'errorDocument cannot be specified with redirectAllRequestsTo';
     }
 
     if (is.inArray('routingRules', clientConfigOptions)) {
-      return 'routingRules cannot be specified with redirectAllRequestsTo';
+      throw 'routingRules cannot be specified with redirectAllRequestsTo';
     }
 
     if (!is.existy(options.redirectAllRequestsTo.hostName)) {
-      return 'redirectAllRequestsTo.hostName is required if redirectAllRequestsTo is specified';
+      throw 'redirectAllRequestsTo.hostName is required if redirectAllRequestsTo is specified';
     }
     if (!is.string(options.redirectAllRequestsTo.hostName)) {
-      return 'redirectAllRequestsTo.hostName must be a string';
+      throw 'redirectAllRequestsTo.hostName must be a string';
     }
 
     if (options.redirectAllRequestsTo.protocol) {
       if (!is.string(options.redirectAllRequestsTo.protocol)) {
-        return 'redirectAllRequestsTo.protocol must be a string';
+        throw 'redirectAllRequestsTo.protocol must be a string';
       }
       if (!is.inArray(options.redirectAllRequestsTo.protocol.toLowerCase(), ['http', 'https'])) {
-        return 'redirectAllRequestsTo.protocol must be either http or https';
+        throw 'redirectAllRequestsTo.protocol must be either http or https';
       }
     }
   }
 
   if (options.routingRules) {
     if (!is.array(options.routingRules)) {
-      return 'routingRules must be a list';
+      throw 'routingRules must be a list';
     }
 
     options.routingRules.forEach(r => {
       if (!is.existy(r.redirect)) {
-        return 'redirect must be specified for each member of routingRules';
+        throw 'redirect must be specified for each member of routingRules';
       }
 
       if (is.existy(r.redirect.replaceKeyPrefixWith) && is.existy(r.redirect.replaceKeyWith)) {
-        return 'replaceKeyPrefixWith and replaceKeyWith cannot both be specified for a member of member of routingRules';
+        throw 'replaceKeyPrefixWith and replaceKeyWith cannot both be specified for a member of member of routingRules';
       }
 
       const redirectProps = [
@@ -113,11 +107,11 @@ function validateClient(serverless, options) {
         if (r.redirect[p]) {
           if (p === 'httpRedirectCode') {
             if (!is.integer(r.redirect[p])) {
-              return 'redirect.httpRedirectCode must be an integer for each member of routingRules';
+              throw 'redirect.httpRedirectCode must be an integer for each member of routingRules';
             }
           } else {
             if (!is.string(r.redirect[p])) {
-              return `redirect.${p} must be a string for each member of routingRules`;
+              throw `redirect.${p} must be a string for each member of routingRules`;
             }
           }
         }
@@ -130,7 +124,7 @@ function validateClient(serverless, options) {
             is.existy(r.condition.keyPrefixEquals)
           )
         ) {
-          return 'condition.httpErrorCodeReturnedEquals or condition.keyPrefixEquals must be defined for each member of routingRules';
+          throw 'condition.httpErrorCodeReturnedEquals or condition.keyPrefixEquals must be defined for each member of routingRules';
         }
 
         const conditionProps = ['httpErrorCodeReturnedEquals', 'keyPrefixEquals'];
@@ -138,11 +132,11 @@ function validateClient(serverless, options) {
           if (r.condition[p]) {
             if (p === 'httpErrorCodeReturnedEquals') {
               if (!is.integer(r.condition[p])) {
-                return 'httpErrorCodeReturnedEquals must be an integer';
+                throw 'httpErrorCodeReturnedEquals must be an integer';
               }
             } else {
               if (!is.string(r.condition[p])) {
-                return `${p} must be a string`;
+                throw `${p} must be a string`;
               }
             }
           }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,36 +10,38 @@ const is = require('is_js');
  * @param {Object} options - Command line options passed to serverless client
  */
 function validateClient(serverless, options) {
+  let validationErrors = [];
+
   // path to website files must exist
   const distributionFolder = options.distributionFolder || path.join('client/dist');
   const clientPath = path.join(serverless.config.servicePath, distributionFolder);
   if (!serverless.utils.dirExistsSync(clientPath)) {
-    throw `Could not find '${clientPath}' folder in your project root`;
+    validationErrors.push(`Could not find '${clientPath}' folder in your project root`);
   }
 
   // bucketName must be a string
   if (!is.string(options.bucketName)) {
-    throw 'Please specify a bucket name for the client in serverless.yml';
+    validationErrors.push('Please specify a bucket name for the client in serverless.yml');
   }
 
   // check header options
   if (options.objectHeaders) {
     if (!is.object(options.objectHeaders)) {
-      throw 'objectHeaders must be an object';
+      validationErrors.push('objectHeaders must be an object');
     }
 
     Object.keys(options.objectHeaders).forEach(p => {
       if (!is.array(options.objectHeaders[p])) {
-        throw 'Each member of objectHeaders must be an array';
+        validationErrors.push('Each member of objectHeaders must be an array');
       }
 
       options.objectHeaders[p].forEach(h => {
         if (!(is.existy(h.name) && is.string(h.name))) {
-          throw `Each object header must have a (string) 'name' attribute`;
+          validationErrors.push(`Each object header must have a (string) 'name' attribute`);
         }
 
         if (!(is.existy(h.value) && is.string(h.value))) {
-          throw `Each object header must have a (string) 'value' attribute`;
+          validationErrors.push(`Each object header must have a (string) 'value' attribute`);
         }
       });
     });
@@ -52,46 +54,50 @@ function validateClient(serverless, options) {
   if (options.redirectAllRequestsTo) {
     const clientConfigOptions = Object.keys(options);
     if (is.inArray('indexDocument', clientConfigOptions)) {
-      throw 'indexDocument cannot be specified with redirectAllRequestsTo';
+      validationErrors.push('indexDocument cannot be specified with redirectAllRequestsTo');
     }
 
     if (is.inArray('errorDocument', clientConfigOptions)) {
-      throw 'errorDocument cannot be specified with redirectAllRequestsTo';
+      validationErrors.push('errorDocument cannot be specified with redirectAllRequestsTo');
     }
 
     if (is.inArray('routingRules', clientConfigOptions)) {
-      throw 'routingRules cannot be specified with redirectAllRequestsTo';
+      validationErrors.push('routingRules cannot be specified with redirectAllRequestsTo');
     }
 
     if (!is.existy(options.redirectAllRequestsTo.hostName)) {
-      throw 'redirectAllRequestsTo.hostName is required if redirectAllRequestsTo is specified';
+      validationErrors.push(
+        'redirectAllRequestsTo.hostName is required if redirectAllRequestsTo is specified'
+      );
     }
     if (!is.string(options.redirectAllRequestsTo.hostName)) {
-      throw 'redirectAllRequestsTo.hostName must be a string';
+      validationErrors.push('redirectAllRequestsTo.hostName must be a string');
     }
 
     if (options.redirectAllRequestsTo.protocol) {
       if (!is.string(options.redirectAllRequestsTo.protocol)) {
-        throw 'redirectAllRequestsTo.protocol must be a string';
+        validationErrors.push('redirectAllRequestsTo.protocol must be a string');
       }
       if (!is.inArray(options.redirectAllRequestsTo.protocol.toLowerCase(), ['http', 'https'])) {
-        throw 'redirectAllRequestsTo.protocol must be either http or https';
+        validationErrors.push('redirectAllRequestsTo.protocol must be either http or https');
       }
     }
   }
 
   if (options.routingRules) {
     if (!is.array(options.routingRules)) {
-      throw 'routingRules must be a list';
+      validationErrors.push('routingRules must be a list');
     }
 
     options.routingRules.forEach(r => {
       if (!is.existy(r.redirect)) {
-        throw 'redirect must be specified for each member of routingRules';
+        validationErrors.push('redirect must be specified for each member of routingRules');
       }
 
       if (is.existy(r.redirect.replaceKeyPrefixWith) && is.existy(r.redirect.replaceKeyWith)) {
-        throw 'replaceKeyPrefixWith and replaceKeyWith cannot both be specified for a member of member of routingRules';
+        validationErrors.push(
+          'replaceKeyPrefixWith and replaceKeyWith cannot both be specified for a member of member of routingRules'
+        );
       }
 
       const redirectProps = [
@@ -105,11 +111,15 @@ function validateClient(serverless, options) {
         if (r.redirect[p]) {
           if (p === 'httpRedirectCode') {
             if (!is.integer(r.redirect[p])) {
-              throw 'redirect.httpRedirectCode must be an integer for each member of routingRules';
+              validationErrors.push(
+                'redirect.httpRedirectCode must be an integer for each member of routingRules'
+              );
             }
           } else {
             if (!is.string(r.redirect[p])) {
-              throw `redirect.${p} must be a string for each member of routingRules`;
+              validationErrors.push(
+                `redirect.${p} must be a string for each member of routingRules`
+              );
             }
           }
         }
@@ -122,7 +132,9 @@ function validateClient(serverless, options) {
             is.existy(r.condition.keyPrefixEquals)
           )
         ) {
-          throw 'condition.httpErrorCodeReturnedEquals or condition.keyPrefixEquals must be defined for each member of routingRules';
+          validationErrors.push(
+            'condition.httpErrorCodeReturnedEquals or condition.keyPrefixEquals must be defined for each member of routingRules'
+          );
         }
 
         const conditionProps = ['httpErrorCodeReturnedEquals', 'keyPrefixEquals'];
@@ -130,17 +142,21 @@ function validateClient(serverless, options) {
           if (r.condition[p]) {
             if (p === 'httpErrorCodeReturnedEquals') {
               if (!is.integer(r.condition[p])) {
-                throw 'httpErrorCodeReturnedEquals must be an integer';
+                validationErrors.push('httpErrorCodeReturnedEquals must be an integer');
               }
             } else {
               if (!is.string(r.condition[p])) {
-                throw `${p} must be a string`;
+                validationErrors.push(`${p} must be a string`);
               }
             }
           }
         });
       }
     });
+  }
+
+  if (validationErrors.length > 0) {
+    throw validationErrors;
   }
 }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -8,8 +8,6 @@ const is = require('is_js');
  * Validates the configuration parameters that will be used for deployment
  * @param {Object} serverless - Instance of the Serverless class
  * @param {Object} options - Command line options passed to serverless client
- *
- * @returns {string} Validation error message (undefined if valid)
  */
 function validateClient(serverless, options) {
   // path to website files must exist


### PR DESCRIPTION
### Background

A test @fernando-mc did on the recent refactor PR (#43) uncovered a scenario where the `serverless.yml` validation step was not working properly and causing an ungaught exception later down the line. 

It turns out that the problem was that the `validateClient` function in `llib/validate.js` was tying to return errors but failing because some of the return statements were in `forEach` loops, which meant that if those pieces didn't validate we would still continue as if they were valid.

Also, the README had not yet been updated with the new `name`/`value` terminology for `objectHeaders` rather than the original `headerName` and `headerValue`

### Proposed changes

I updated the `validateClient` function to throw errors rather than returning errors, as well as updating a little piece of logic in the `objectHeaders` validation. This change also required some minor reorganization of the `_validateConfig`, `_removeDeployedResources` and `_processDeployment` functions in `index.js`

I also made the little README update.

### Proposed reviewers

@fernando-mc 
