### PR TITLE
Added CLI option to disable confirmation prompt and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,18 @@ Use this parameter if you do not want to overwrite the bucket CORS configuration
 
 ---
 
+**--no-confirm**
+
+_optional_, default `false` (disables confirmation prompt)
+
+```bash
+serverless client deploy --no-confirm
+```
+
+Use this parameter if you do not want a confirmation prompt to interrupt automated builds.
+
+---
+
 ## Contributing
 
 For guidelines on contributing to the project, please refer to our [Contributing](docs/CONTRIBUTING.md) page. 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class Client {
     return this._validateConfig()
       .then(() => {
         bucketName = this.options.bucketName;
-        return new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
+        return this.cliOptions.confirm === false ? true : new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
       })
       .then(goOn => {
         if (goOn) {
@@ -148,7 +148,7 @@ class Client {
         }
 
         deployDescribe.forEach(m => this.serverless.cli.log(m));
-        return new Confirm(`Do you want to proceed?`).run();
+        return this.cliOptions.confirm === false ? true : new Confirm(`Do you want to proceed?`).run();
       })
       .then(goOn => {
         if (goOn) {


### PR DESCRIPTION
### Background

See comments regarding confirmation prompt in (already closed) #47.

For automated builds the confirmation prompt would stall the process. 

### Proposed changes

The new --no-confirm CLI option allows scripts to disable the prompt for automated builds.


