### PR TITLE
make sure path seperators are '/' in S3 key (fixes #51)

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -78,10 +78,14 @@ function buildUploadList(files, clientRoot, headerSpec) {
   const uploadList = files.map(f => {
     const filePath = path.normalize(f);
     const fileRelPath = filePath.replace(clientRoot, '');
+    const fileKey = path
+      .normalize(fileRelPath)
+      .split(path.sep)
+      .join('/');
 
     let upload = {
       filePath: filePath,
-      fileKey: filePath.replace(clientRoot, ''),
+      fileKey: fileKey,
       headers: {}
     };
 


### PR DESCRIPTION
### Background

Fixes bug described in #51 

### Proposed changes

Replace system-native path separators with '/' for AWS key

I was able to replicate the bug on my Windows machine. This PR fixes the issue on Windows for me. It also still passes manual checks on Ubuntu.

### Proposed reviewers

@fernando-mc 
@cloudandcode
