### PR TITLE
Allow glob pattern to add headers to matching files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ custom:
         - name: [header-name]
           value: [header-value]
         ...
+      'someGlobPattern/*.html':
+        - name: [header-name]
+          value: [header-value]
+        ...
       specific-directory/:
         - name: [header-name]
           value: [header-value]

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -9,6 +9,8 @@ const mime = require('mime');
 const getFileList = require('./utilities/getFileList');
 const regionUrls = require('./resources/awsRegionUrls');
 
+const minimatch = require('minimatch');
+
 /**
  * Uploads client files to an S3 bucket
  * @param {Object} aws - AWS class
@@ -99,6 +101,17 @@ function buildUploadList(files, clientRoot, headerSpec) {
         upload.headers[h.name] = h.value;
       });
     }
+
+    // add headers by glob pattern
+    Object.keys(headerSpec)
+      .filter(s => !!s.match(/[\*\?\[\]]/)) // Potential glob pattern
+      .filter(s => minimatch(fileRelPath, s, { matchBase: true }))
+      .sort((a, b) => a.length - b.length) // sort by length ascending
+      .forEach(s => {
+        headerSpec[s].forEach(h => {
+          upload.headers[h.name] = h.value;
+        });
+      });
 
     // add folder-level headers
     Object.keys(headerSpec)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "is_js": "^0.9.0",
     "lodash": "^4.2.1",
     "mime": "^1.2.11",
+    "minimatch": "^3.0.4",
     "prompt-confirm": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Background
Allow glob pattern (wildcards) usage when adding headers.
So, we can add headers to all html files or any other kinds of files:
```yaml
custom:
  client:
    ...
    objectHeaders:
      '*.html':
        - name: [header-name]
          value: [header-value]
        ...
      ... [more file- or folder-specific rules]
    ...
```