### PR TITLE
adds uploadOrder configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,24 @@ _If `condition` is not specified, then all requests will be redirected in accord
 
 ---
 
+**uploadOrder**
+
+_optional_, no default
+
+```yaml
+custom:
+  client:
+    ...
+    uploadOrder:
+      - .*
+      - .*/assets/.*
+      - service-worker\.js
+      - index\.html
+    ...
+```
+
+The `uploadOrder` option can be used for ordering the files uploaded to the bucket.  When combined with `--no-delete-contents` this helps with 0 downtime, as we can make sure we upload any assets before serving the html files which need them.
+
 ### Command-line Parameters
 
 **--region**

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ class Client {
       clientPath,
       bucketName,
       headerSpec,
+      orderSpec,
       indexDoc,
       errorDoc,
       redirectAllRequestsTo,
@@ -127,6 +128,7 @@ class Client {
         clientPath = path.join(this.serverless.config.servicePath, distributionFolder);
         bucketName = this.options.bucketName;
         headerSpec = this.options.objectHeaders;
+        orderSpec = this.options.uploadOrder;
         indexDoc = this.options.indexDocument || 'index.html';
         errorDoc = this.options.errorDocument || 'error.html';
         redirectAllRequestsTo = this.options.redirectAllRequestsTo || null;
@@ -210,7 +212,7 @@ class Client {
             })
             .then(() => {
               this.serverless.cli.log(`Uploading client files to bucket...`);
-              return uploadDirectory(this.aws, bucketName, clientPath, headerSpec);
+              return uploadDirectory(this.aws, bucketName, clientPath, headerSpec, orderSpec);
             })
             .then(() => {
               this.serverless.cli.log(

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -17,17 +17,22 @@ const minimatch = require('minimatch');
  * @param {string} bucketName - Name of bucket to be configured
  * @param {string} clientRoot - Full path to the root directory of client files
  * @param {Object[]} headerSpec - Array of header values to add to files
+ * @param {string[]} orderSpec - Array of regex's to order upload by
  */
-function uploadDirectory(aws, bucketName, clientRoot, headerSpec) {
+function uploadDirectory(aws, bucketName, clientRoot, headerSpec, orderSpec) {
   const allFiles = getFileList(clientRoot);
 
-  const uploadList = buildUploadList(allFiles, clientRoot, headerSpec);
+  const filesGroupedByOrder = groupFilesByOrder(allFiles, orderSpec);
 
-  return BbPromise.all(
-    uploadList.map(u => {
-      return uploadFile(aws, bucketName, u.filePath, u.fileKey, u.headers);
-    })
-  );
+  return filesGroupedByOrder.reduce((existingUploads, files) => {
+    return existingUploads.then(existingResults => {
+      const uploadList = buildUploadList(files, clientRoot, headerSpec);
+
+      return BbPromise.all(
+        uploadList.map(u => uploadFile(aws, bucketName, u.filePath, u.fileKey, u.headers))
+      ).then(currentResults => existingResults.concat(currentResults));
+    });
+  }, Promise.resolve([]));
 }
 
 /**
@@ -140,6 +145,29 @@ function buildUploadList(files, clientRoot, headerSpec) {
   });
 
   return uploadList;
+}
+
+function groupFilesByOrder(files, orderSpec) {
+  if (!orderSpec) {
+    return [files];
+  }
+
+  const orderedFiles = files.map(f => ({ file: f, order: 0 }));
+
+  orderSpec.forEach((orderRegex, i) => {
+    const re = new RegExp(orderRegex, 'i');
+    orderedFiles.forEach(f => {
+      if (re.test(f.file)) {
+        f.order = i + 1;
+      }
+    });
+  });
+
+  const unmatchedFiles = orderedFiles.filter(f => f.order === 0).map(f => f.file);
+  const matchedFiles = orderSpec.map((orderRegex, i) =>
+    orderedFiles.filter(f => f.order === i + 1).map(f => f.file)
+  );
+  return [unmatchedFiles].concat(matchedFiles);
 }
 
 module.exports = uploadDirectory;


### PR DESCRIPTION
Hi, I've attempted to fix issue #63.

Adds configuration option 'uploadOrder' as a list of case insensitive regex's.  They're in order of first to upload to last, with later matches overriding the earlier. Therefore it would be best to start with more
generic regex's to more specific.

In the implementation instead of it uploading all files in one set of promises, it bunches up files into order groups and uploads the groups sequentially.