### PR TITLE
Give more instructions on bucket policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,13 @@ The name of your error document inside your `distributionFolder`. This is the fi
 custom:
   client:
     ...
-    bucketPolicyFile: [path/to/policy.json]
+    bucketPolicyFile: "${env:PWD}/path/to/policy.json"
     ...
 ```
 
-Use this parameter to specify the path to a custom policy file. If not set, it defaults to a config for a basic static website. Currently, only JSON is supported. In your policy, make sure that your resource has the correct bucket name specified above: `"Resource": "arn:aws:s3:::BUCKET_NAME/*",`
+Use this parameter to specify the path to a _single_ custom policy file. If not set, it defaults to a config for a basic static website. Currently, only JSON is supported. In your policy, make sure that your resource has the correct bucket name specified above: `"Resource": "arn:aws:s3:::BUCKET_NAME/*",`
+
+_Note: As in the example you will want to use `${env:PWD}` if you want to dynamically specify the policy within your repo. Additionally, you will want to specify different policies depending on your stage using `${self:provider.stage}` to ensure your `BUCKET_NAME` corosponds to the stage._
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins:
 
 custom:
   client:
-    bucketName: "unique-s3-bucketname" # (see Configuration Parameters below)
+    bucketName: unique-s3-bucketname # (see Configuration Parameters below)
     # [other configuration parameters] (see Configuration Parameters below)
 ```
 
@@ -136,7 +136,25 @@ custom:
 
 Use this parameter to specify the path to a _single_ custom policy file. If not set, it defaults to a config for a basic static website. Currently, only JSON is supported. In your policy, make sure that your resource has the correct bucket name specified above: `"Resource": "arn:aws:s3:::BUCKET_NAME/*",`
 
-_Note: As in the example you will want to use `${env:PWD}` if you want to dynamically specify the policy within your repo. Additionally, you will want to specify different policies depending on your stage using `${self:provider.stage}` to ensure your `BUCKET_NAME` corosponds to the stage._
+_Note: You can also use `${env:PWD}` if you want to dynamically specify the policy within your repo. for example:_ 
+
+```yaml
+custom:
+  client:
+    ...
+    bucketPolicyFile: "${env:PWD}/path/to/policy.json"
+    ...
+```
+
+_Additionally, you will want to specify different policies depending on your stage using `${self:provider.stage}` to ensure your `BUCKET_NAME` corosponds to the stage._
+
+```yaml
+custom:
+  client:
+    ...
+    bucketPolicyFile: "/path/to/policy-${self:provider.stage}.json"
+    ...
+```
 
 ---
 
@@ -165,7 +183,7 @@ custom:
         - name: header-name
           value: header-value
         ...
-      ... [more file- or folder-specific rules]
+      ... # more file- or folder-specific rules
     ...
 ```
 
@@ -187,7 +205,7 @@ custom:
     ...
     redirectAllRequestsTo:
       hostName: hostName
-      protocol: "[http|https]"
+      protocol: protocol # "http" or "https"
     ...
 ```
 
@@ -209,11 +227,11 @@ custom:
       - redirect:
           hostName: hostName
           httpRedirectCode: httpCode
-          protocol: "[http|https]"
+          protocol: protocol # "http" or "https"
           replaceKeyPrefixWith: prefix
           replaceKeyWith: [object]
         condition:
-          keyPrefixEquals: [prefix]
+          keyPrefixEquals: prefix
           httpErrorCodeReturnedEquals: httpCOde
       - ...
     ...

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins:
 
 custom:
   client:
-    bucketName: [unique-s3-bucketname] # (see Configuration Parameters below)
+    bucketName: "unique-s3-bucketname" # (see Configuration Parameters below)
     # [other configuration parameters] (see Configuration Parameters below)
 ```
 
@@ -69,7 +69,7 @@ _required_
 ```yaml
 custom:
   client:
-    bucketName: [unique-s3-bucketname]
+    bucketName: unique-s3-bucketname
 ```
 
 Use this parameter to specify a unique name for the S3 bucket that your files will be uploaded to.
@@ -84,7 +84,7 @@ _optional_, default: `client/dist`
 custom:
   client:
     ...
-    distributionFolder: [path/to/files]
+    distributionFolder: path/to/files
     ...
 ```
 
@@ -100,7 +100,7 @@ _optional_, default: `index.html`
 custom:
   client:
     ...
-    indexDocument: [file-name.ext]
+    indexDocument: file-name.ext
     ...
 ```
 
@@ -116,7 +116,7 @@ _optional_, default: `error.html`
 custom:
   client:
     ...
-    errorDocument: [file-name.ext]
+    errorDocument: file-name.ext
     ...
 ```
 
@@ -130,7 +130,7 @@ The name of your error document inside your `distributionFolder`. This is the fi
 custom:
   client:
     ...
-    bucketPolicyFile: "${env:PWD}/path/to/policy.json"
+    bucketPolicyFile: path/to/policy.json
     ...
 ```
 
@@ -150,20 +150,20 @@ custom:
     ...
     objectHeaders:
       ALL_OBJECTS:
-        - name: [header-name]
-          value: [header-value]
+        - name: header-name
+          value: header-value
         ...
       'someGlobPattern/*.html':
-        - name: [header-name]
-          value: [header-value]
+        - name: header-name
+          value: header-value
         ...
       specific-directory/:
-        - name: [header-name]
-          value: [header-value]
+        - name: header-name
+          value: header-value
         ...
       specific-file.ext:
-        - name: [header-name]
-          value: [header-value]
+        - name: header-name
+          value: header-value
         ...
       ... [more file- or folder-specific rules]
     ...
@@ -186,8 +186,8 @@ custom:
   client:
     ...
     redirectAllRequestsTo:
-      hostName: [hostName]
-      protocol: [http|https]
+      hostName: hostName
+      protocol: "[http|https]"
     ...
 ```
 
@@ -207,15 +207,15 @@ custom:
     ...
     routingRules:
       - redirect:
-          hostName: [hostName]
-          httpRedirectCode: [CODE]
-          protocol: [http|https]
-          replaceKeyPrefixWith: [prefix]
+          hostName: hostName
+          httpRedirectCode: httpCode
+          protocol: "[http|https]"
+          replaceKeyPrefixWith: prefix
           replaceKeyWith: [object]
         condition:
           keyPrefixEquals: [prefix]
-          httpErrorCodeReturnedEquals: [CODE]
-      - [more-rules...]
+          httpErrorCodeReturnedEquals: httpCOde
+      - ...
     ...
 ```
 


### PR DESCRIPTION
### Background

Since `[some/path/here.json]` translates to `["some/path/here.json"]` it is confusing and I thought the policy required an array of strings.

### Proposed changes

Update the README and us `"some/path/policy.json"` instead. Also added some tips about env paths since finch will try and look in serverless-finch module directory path for relative path policies.
