### PR TITLE
Add httpsOnly flag, custom.client.httpsOnly, boolean option

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,8 @@ class Client {
               const bucketPolicyFile = this.serverless.service.custom.client.bucketPolicyFile;
               const customPolicy =
                 bucketPolicyFile && JSON.parse(fs.readFileSync(bucketPolicyFile));
-              return configure.configurePolicyForBucket(this.aws, bucketName, customPolicy);
+              const httpsOnly = this.serverless.service.custom.client.httpsOnly || false;
+              return configure.configurePolicyForBucket(this.aws, bucketName, customPolicy, httpsOnly);
             })
             .then(() => {
               if (this.cliOptions['cors-change'] === false || manageResources === false) {
@@ -256,10 +257,14 @@ class Client {
               );
             })
             .then(() => {
+              // S3 HTTPS is terminated on a different URL
+              const httpsOnly = this.serverless.service.custom.client.httpsOnly || false;
+              const siteUrl = httpsOnly
+                  ? `https://s3.${region}.amazonaws.com/${bucketName}/`
+                  : `http://${bucketName}.${regionUrls[region]}/`;
+
               this.serverless.cli.log(
-                `Success! Your site should be available at http://${bucketName}.${
-                  regionUrls[region]
-                }/`
+                `Success! Your site should be available at ${siteUrl}`
               );
             });
         }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -89,21 +89,54 @@ function configureBucket(
  * Configures policy for given bucket
  * @param {Object} aws - AWS class
  * @param {string} bucketName - Name of bucket to be configured
+ * @param {Object} customPolicy - AWS custom policy for this bucket, can be undefined
+ * @param {boolean} httpsOnly - Configure the bucket policy to block plain HTTP requests, customPolicy overrides this
  */
-function configurePolicyForBucket(aws, bucketName, customPolicy) {
-  const policy = customPolicy || {
-    Version: '2012-10-17',
-    Statement: [
+function configurePolicyForBucket(aws, bucketName, customPolicy, httpsOnly) {
+  const PERMISSIVE_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
       {
-        Effect: 'Allow',
-        Principal: {
-          AWS: '*'
+        "Sid": "PublicReadGetObject",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "*"
         },
-        Action: 's3:GetObject',
-        Resource: `arn:aws:s3:::${bucketName}/*`
+        "Action": "s3:GetObject",
+        "Resource": `arn:aws:s3:::${bucketName}/*`
       }
     ]
   };
+
+  const HTTPS_ONLY_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "PublicReadGetObject",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Action": "s3:GetObject",
+        "Resource": `arn:aws:s3:::${bucketName}/*`
+      },
+      {
+        "Sid": "PublicReadGetObject",
+        "Effect": "Deny",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Action": "s3:GetObject",
+        "Resource": `arn:aws:s3:::${bucketName}/*`,
+        "Condition":{
+          "Bool":
+              { "aws:SecureTransport": false }
+        }
+      }
+    ]
+  };
+
+  const policy = customPolicy || (httpsOnly ? HTTPS_ONLY_POLICY : PERMISSIVE_POLICY);
 
   const params = {
     Bucket: bucketName,


### PR DESCRIPTION
### Background
As a Developer I'm using an S3 site for hosting callback URLs from Cognito and would like to make it difficult to accidentally have ID and Access Tokens flying around the internets into the clear.  I would like to enforce an HTTPS Everywhere style policy.  I don't want to terminate HTTPS in Cloudfront during development.

The same effect can be achieved by providing a custom bucketPolicyFile however this isn't very DRY because the user has to provide the bucket name in three places (serverless.yaml and twice within the policy file).

### Proposed changes
Add an httpsOnly flag to serverless.yml configuration file.  This adjusts the bucket policy accordingly.

If the Developer specifies a custom bucketPolicyFile, then the httpsOnly flag is disregarded.

### Known Issues
Due to the AWS terminate HTTPS (and wildcard certificates), I need to change the URL printed to the user following an `sls client deploy`
