### PR TITLE
fix: deep upload paths are incorrectly resolved (e.g. with keyPrefix 'a/b' path resolves to 'a,b')

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -91,7 +91,7 @@ function buildUploadList(files, clientRoot, headerSpec, keyPrefix) {
     const fileRelPath = filePath.replace(clientRoot, '');
     const fileKey = path.normalize(fileRelPath).split(path.sep);
     if (prefix.length) {
-      fileKey.unshift(prefix);
+      fileKey.unshift(...prefix);
     }
     const upload = {
       filePath: filePath,


### PR DESCRIPTION
### Background

Fixes https://github.com/fernando-mc/serverless-finch/issues/86 (Deep upload paths specified with keyPrefix get resolved incorrectly

### Proposed changes

Flattening the fileKey array before doing a `.join('/')` results in a correct expected behaviour.

### Proposed reviewers (optional)

@fernando-mc 