### PR TITLE
Add support for Server Side Encryption of uploaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,24 @@ Adding a keyPrefix option, so that it's possibly to upload files to a prefixed s
 
 ---
 
+**sse**
+
+_optional_, no default
+
+```yaml
+custom:
+  client:
+    ...
+    sse: AES256
+    ...
+```
+
+Enable server side encryption for the uploaded files.
+
+[AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
+
+---
+
 **manageResources**
 
 _optional_, default `true` (the plugin does manage your resources by default)

--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ class Client {
   }
 
   _removeDeployedResources() {
-
     let bucketName, manageResources, keyPrefix;
 
     return this._validateConfig()
@@ -95,7 +94,6 @@ class Client {
                   }
                 })
                 .then(() => {
-
                   if (manageResources === false) {
                     this.serverless.cli.log(`Success! Your files have been removed`);
                   } else {
@@ -130,6 +128,7 @@ class Client {
       errorDoc,
       redirectAllRequestsTo,
       keyPrefix,
+      sse,
       routingRules,
       manageResources;
 
@@ -153,6 +152,7 @@ class Client {
         clientPath = path.join(this.serverless.config.servicePath, distributionFolder);
         bucketName = this.options.bucketName;
         keyPrefix = this.options.keyPrefix;
+        sse = this.options.sse || null;
         manageResources = this.options.manageResources;
         headerSpec = this.options.objectHeaders;
         orderSpec = this.options.uploadOrder;
@@ -252,14 +252,13 @@ class Client {
                 clientPath,
                 headerSpec,
                 orderSpec,
-                keyPrefix
+                keyPrefix,
+                sse
               );
             })
             .then(() => {
               this.serverless.cli.log(
-                `Success! Your site should be available at http://${bucketName}.${
-                  regionUrls[region]
-                }/`
+                `Success! Your site should be available at http://${bucketName}.${regionUrls[region]}/`
               );
             });
         }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -18,8 +18,9 @@ const minimatch = require('minimatch');
  * @param {Object[]} headerSpec - Array of header values to add to files
  * @param {string[]} orderSpec - Array of regex's to order upload by
  * @param {string} keyPrefix - A prefix for all files uploaded
+ * @param {string} sse - ServerSideEncryption, AES256 | aws:kms | null
  */
-function uploadDirectory(aws, bucketName, clientRoot, headerSpec, orderSpec, keyPrefix) {
+function uploadDirectory(aws, bucketName, clientRoot, headerSpec, orderSpec, keyPrefix, sse) {
   const allFiles = getFileList(clientRoot);
 
   const filesGroupedByOrder = groupFilesByOrder(allFiles, orderSpec);
@@ -29,7 +30,7 @@ function uploadDirectory(aws, bucketName, clientRoot, headerSpec, orderSpec, key
       const uploadList = buildUploadList(files, clientRoot, headerSpec, keyPrefix);
 
       return Promise.all(
-        uploadList.map(u => uploadFile(aws, bucketName, u.filePath, u.fileKey, u.headers))
+        uploadList.map(u => uploadFile(aws, bucketName, u.filePath, u.fileKey, u.headers, sse))
       ).then(currentResults => existingResults.concat(currentResults));
     });
   }, Promise.resolve([]));
@@ -40,9 +41,11 @@ function uploadDirectory(aws, bucketName, clientRoot, headerSpec, orderSpec, key
  * @param {Object} aws - AWS class
  * @param {string} bucketName - Name of bucket to be configured
  * @param {string} filePath - Full path to file to be uploaded
- * @param {string} clientRoot - Full path to the root directory of client files
+ * @param {string} fileKey -
+ * @param {string} headers -
+ * @param {string} sse - ServerSideEncryption, AES256 | aws:kms | null
  */
-function uploadFile(aws, bucketName, filePath, fileKey, headers) {
+function uploadFile(aws, bucketName, filePath, fileKey, headers, sse) {
   const baseHeaderKeys = [
     'Cache-Control',
     'Content-Disposition',
@@ -61,6 +64,10 @@ function uploadFile(aws, bucketName, filePath, fileKey, headers) {
     Body: fileBuffer,
     ContentType: mime.lookup(filePath)
   };
+
+  if (sse) {
+    params.ServerSideEncryption = sse;
+  }
 
   Object.keys(headers).forEach(h => {
     if (baseHeaderKeys.includes(h)) {
@@ -81,7 +88,7 @@ function buildUploadList(files, clientRoot, headerSpec, keyPrefix) {
   if (!clientRoot.endsWith(path.sep)) {
     clientRoot += path.sep;
   }
-  if (keyPrefix){
+  if (keyPrefix) {
     var prefix = keyPrefix.split(path.sep);
   } else {
     var prefix = [];


### PR DESCRIPTION
### Background

Currently uploding files to a bucket that requires server side encryption is not possible. This feature adds support for these use cases.

### Proposed changes

- optional `sse` option in which the encryption algorithm can be defined

