### PR TITLE
Fix bucket deletion when using keyPrefix

### DIFF
--- a/lib/bucketUtils.js
+++ b/lib/bucketUtils.js
@@ -65,6 +65,10 @@ function emptyBucket(aws, bucketName, keyPrefix) {
         return {Key: content.Key};
       }).filter(content => !testPrefix || prefixRegexp.test(content.Key));
 
+      if (objects.length === 0) {
+        return Promise.resolve()
+      }
+
       const params = {
         Bucket: bucketName,
         Delete: { Objects: objects }


### PR DESCRIPTION
### Background

When using the `keyPrefix` option along with having bucket deletion enabled, the following error occurs if the key prefix does not already exist:
```
ServerlessError: The XML you provided was not well-formed or did not validate against our published schema
```

Closes #85 

### Proposed changes

The issue was with the `emptyBucket` function. With no items containing the keyPrefix, the keyPrefix logic resulted in an empty array of S3 objects being passed to the `deleteObjects` S3 request. This fix resolves the promise if there are no objects to delete.
