### PR TITLE
adds logic to upload compressed files with right mime type and right content-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Headers may be specified globally for all files in the bucket by adding a `name`
 
 Headers with more specificity will take precedence over more general ones. For instance, if 'Cache-Control' was set to 'max-age=100' in `ALL_OBJECTS` and to 'max-age=500' in `my/folder/`, the files in `my/folder/` would get a header of 'Cache-Control: max-age=500'.
 
+'Content-Type' is autmomatically inferred from the file extension and added to the header collection. If the file is compressed and has the additional extension `.gz` or `br`, a 'Content-Encoding' header will be added as well to describe the object as gzip or brotli encoded.
+
 ---
 
 **redirectAllRequestsTo**

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -62,7 +62,7 @@ function uploadFile(aws, bucketName, filePath, fileKey, headers, sse) {
     Bucket: bucketName,
     Key: fileKey,
     Body: fileBuffer,
-    ContentType: mime.getType(filePath)
+    ...getMimeTypeAndContentEncoding(filePath)
   };
 
   if (sse) {
@@ -178,6 +178,26 @@ function groupFilesByOrder(files, orderSpec) {
     orderedFiles.filter(f => f.order === i + 1).map(f => f.file)
   );
   return [unmatchedFiles].concat(matchedFiles);
+}
+
+const ContentEncodingMap = {
+  gz: 'gzip',
+  br: 'br'
+};
+
+function getMimeTypeAndContentEncoding(filePath) {
+  const match = /(.+\..+)\.(gz|br)$/.exec(filePath);
+
+  if (match) {
+    const [fullMatch, strippedFilePath, encodingFileEnding] = match;
+
+    return {
+      ContentType: mime.getType(strippedFilePath),
+      ContentEncoding: ContentEncodingMap[encodingFileEnding]
+    };
+  }
+
+  return { ContentType: mime.getType(filePath) };
 }
 
 module.exports = uploadDirectory;


### PR DESCRIPTION
### Background

 #https://github.com/fernando-mc/serverless-finch/issues/81

### Proposed changes

If not specified within the `objectHeaders` option, uploaded objects are given a content-type header automatically based on their file extension using [mime](https://www.npmjs.com/package/mime) 's lookup function. Unfortunately, this causes problems if you attempt to upload a file with a file extension + a compression extension. ie `main.123.js.gz` . 

Now, there aren't any standards (that I know of ) to reference here, but the common practice that I've seen is that gzip compressed files follow the pattern

`*.{file-extension}.gz`

and brotli compressed files follow this pattern:

`*.{file-extension}.br`

I haven't come across anything for other compression encoding types, but I would be happy to add support in this PR

If we assume that users who precompress their file will follow the above described practice, then this merging this PR will do the following:

1. Files matching `*.*.br` will be given a `Content-Encoding` header value of `br`, in accordance with [brotli standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
1. Files ending with `*.*.gz` will be given a `Content-Encoding` header value of `gzip` in accordance with [gzip standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
1. Files that do not match either above pattern will be passed to the existing logic and given a mime type based on file extension
