### PR TITLE
Add keyprefix to deployDescribe log

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ class Client {
       sse,
       routingRules,
       manageResources,
-      tags;
+      tags,
+      prefixText;
 
     return this._validateConfig()
       .then(() => {
@@ -163,13 +164,17 @@ class Client {
         routingRules = this.options.routingRules || null;
         tags = this.options.tags || []
 
+        if(keyPrefix) {
+            prefixText = `under the prefix '${keyPrefix}'`
+        }
+
         const deployDescribe = ['This deployment will:'];
 
         if (this.cliOptions['delete-contents']) {
           deployDescribe.push(`- Remove all existing files from bucket '${bucketName}'`);
         }
         deployDescribe.push(
-          `- Upload all files from '${distributionFolder}' to bucket '${bucketName}'`
+          `- Upload all files from '${distributionFolder}' to bucket '${bucketName}' ${prefixText}`
         );
 
         if (this.cliOptions['config-change'] !== false && manageResources !== false) {


### PR DESCRIPTION
### Background
Current usage is quite misleading as this text can be interpreted as it will overwrite the whole bucket.
<img width="800" alt="Screenshot 2020-11-25 at 14 59 31" src="https://user-images.githubusercontent.com/6134511/100237273-00e66680-2f2f-11eb-8209-c4042302780e.png">
