### PR TITLE
Keeps empty string in ReplaceKeyWith 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 A Serverless Framework plugin for deployment of static website assets of your Serverless project to AWS S3.
 
+## Patched version
+This package is a patched version of serverless-finch.
+The patch allows to set the "redirect" property of routing rules to be an empty string, which is a legitimate value.
+This package can be removed once the Pull Request has been accepted in the official serverless-finch package.
+
 ## Installation
 
 ```

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -52,7 +52,9 @@ function configureBucket(
         'replaceKeyWith'
       ];
       redirectProps.forEach(p => {
-        if (r.redirect[p]) {
+        // a property can be legitimately an empty string which has to be registered in the configuration as such, for
+        // instance in the case of "ReplaceKeyWith" where an empty string means to go to the Index document configured
+        if (r.redirect[p] || r.redirect[p] === '') {
           if (p === 'httpRedirectCode') {
             r.redirect[p] = r.redirect[p].toString();
           }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "serverless-finch",
-  "version": "2.6.0",
+  "name": "serverless-finch-patched-for-redirect",
+  "version": "2.6.3",
   "engines": {
     "node": ">=4.0"
   },
-  "description": "Deploy your serverless static website to AWS S3.",
+  "description": "Deploy your serverless static website to AWS S3. Based on serverless-finch 2.6.0. ",
   "main": "index.js",
   "scripts": {
     "precommit": "lint-staged",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fernando-mc/serverless-finch.git"
+    "url": "git+https://github.com/EnricoPicci/serverless-finch.git"
   },
   "keywords": [
     "serverless",

--- a/test/automated_tests.py
+++ b/test/automated_tests.py
@@ -57,6 +57,16 @@ else:
     print("################## TEST4 PASSES########################")
 remove()
 
+# routing rules with "replaceKeyWith" se to empty string
+os.system("cp ./config_files/routing-rules-redirect.yml ./serverless.yml")
+os.system("sls client deploy --no-confirm")
+result = s3.get_bucket_website(Bucket='BUCKET_NAME')
+if res['RoutingRules'][0]['ReplaceKeyWith'] != '':
+    raise Exception("Isn't setting ReplaceKeyWith with an empty string")
+else:
+    print("################## TEST5 PASSES########################")
+remove()
+
 # Clean up node modules after all tests pass
 os.system("rm -r node_modules")
 os.system("rm ../serverless-finch-?*.?*.?*.tgz")

--- a/test/automated_tests.py
+++ b/test/automated_tests.py
@@ -61,7 +61,7 @@ remove()
 os.system("cp ./config_files/routing-rules-redirect.yml ./serverless.yml")
 os.system("sls client deploy --no-confirm")
 result = s3.get_bucket_website(Bucket='BUCKET_NAME')
-if res['RoutingRules'][0]['ReplaceKeyWith'] != '':
+if res['RoutingRules'][0]["Redirect"]['ReplaceKeyWith'] != '':
     raise Exception("Isn't setting ReplaceKeyWith with an empty string")
 else:
     print("################## TEST5 PASSES########################")

--- a/test/config_files/routing-rules-redirect.yml
+++ b/test/config_files/routing-rules-redirect.yml
@@ -1,0 +1,18 @@
+service: serverless-finch-test
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+
+plugins:
+  - serverless-finch
+
+custom:
+  client:
+    bucketName: sls-finch-test-routing-use1
+    indexDocument: index.html
+    errorDocument: error.html
+    routingRules:
+      - redirect: { replaceKeyWith: "" }
+        condition:
+          httpErrorCodeReturnedEquals: 404


### PR DESCRIPTION
### Background

When setting RoutingRules it is legitimate to have an empty string as value of property ReplaceKeyWith, since this would signal that the redirect goes to the Index document defined

### Proposed changes

Accepts empty strings as valid values for redirectProps


