### PR TITLE
Don't use deprecated log method

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
+    "arrowParens": "avoid",
     "printWidth": 100,
-    "singleQuote": true
+    "singleQuote": true,
+    "trailingComma": "none"
 }


### PR DESCRIPTION
In Serverless 3, `serverles.cli.log` is [deprecated](https://www.serverless.com/framework/docs/guides/plugins/cli-output#writing-to-the-output).  This PR simply changes over to use the recommended log method.

It also includes a change to the Prettier configuration to preserve the same formatting that was present before Prettier was upgraded to v2. Eventually maybe we want to change this config, but better to do that in a separate PR where all files are reformatted.