### PR TITLE
fix(log): don't log undefined string

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -156,8 +156,7 @@ class Client {
       sse,
       routingRules,
       manageResources,
-      tags,
-      prefixText;
+      tags;
 
     return this._validateConfig()
       .then(() => {
@@ -189,17 +188,15 @@ class Client {
         routingRules = this.options.routingRules || null;
         tags = this.options.tags || [];
 
-        if (keyPrefix) {
-          prefixText = `under the prefix '${keyPrefix}'`;
-        }
-
         const deployDescribe = ['This deployment will:'];
 
         if (this.cliOptions['delete-contents']) {
           deployDescribe.push(`- Remove all existing files from bucket '${bucketName}'`);
         }
         deployDescribe.push(
-          `- Upload all files from '${distributionFolder}' to bucket '${bucketName}' ${prefixText}`
+          `- Upload all files from '${distributionFolder}' to bucket '${bucketName}'${
+            keyPrefix ? ` under the prefix '${keyPrefix}'` : ''
+          }`
         );
 
         if (this.cliOptions['config-change'] !== false && manageResources !== false) {


### PR DESCRIPTION
Fixes a small issue when no keyPrefix is specified, the log output would include "undefined":

```
This deployment will:
- Upload all files from 'client\dist' to bucket 'my-bucket' undefined
```
