### PR TITLE
fix(bucket-utils): bucket creation now removes the public access bloc…

### DIFF
--- a/lib/bucket-utils.js
+++ b/lib/bucket-utils.js
@@ -95,7 +95,11 @@ function createBucket(aws, bucketName) {
     Bucket: bucketName
   };
 
-  return aws.request('S3', 'createBucket', params);
+  return aws.request('S3', 'createBucket', params).then(() => {
+    aws.request('S3', 'deletePublicAccessBlock', {
+      Bucket: bucketName
+    });
+  });
 }
 
 module.exports = {

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -15,6 +15,7 @@ const { expect } = require('chai');
 describe('client deploy', () => {
   let createBucketStub;
   let deleteObjectsStub;
+  let deletePublicAccessBlockStub;
   let putBucketCorsStub;
   let putBucketPolicyStub;
   let putBucketTaggingStub;
@@ -24,6 +25,7 @@ describe('client deploy', () => {
   beforeEach(() => {
     createBucketStub = sinon.stub();
     deleteObjectsStub = sinon.stub();
+    deletePublicAccessBlockStub = sinon.stub();
     putBucketCorsStub = sinon.stub();
     putBucketPolicyStub = sinon.stub();
     putBucketTaggingStub = sinon.stub();
@@ -37,7 +39,11 @@ describe('client deploy', () => {
     await deploy('basic');
 
     expect(createBucketStub).to.be.calledOnce;
+    expect(deletePublicAccessBlockStub).to.be.calledOnce;
     expect(createBucketStub).to.be.calledWithExactly({
+      Bucket: 'my-website-bucket'
+    });
+    expect(deletePublicAccessBlockStub).to.be.calledWithExactly({
       Bucket: 'my-website-bucket'
     });
   });
@@ -259,6 +265,7 @@ describe('client deploy', () => {
         S3: {
           createBucket: createBucketStub,
           deleteObjects: deleteObjectsStub,
+          deletePublicAccessBlock: deletePublicAccessBlockStub,
           listBuckets: {
             Buckets: [{ Name: 'existing-bucket' }]
           },
@@ -281,6 +288,7 @@ describe('client remove', () => {
   let deleteObjectsStub;
   let listBucketsStub;
   let listObjectsV2Stub;
+  let deletePublicAccessBlockStub;
 
   beforeEach(() => {
     deleteBucketStub = sinon.stub();
@@ -382,6 +390,7 @@ describe('client remove', () => {
       awsRequestStubMap: {
         S3: {
           deleteBucket: deleteBucketStub,
+          deletePublicAccessBlock: deletePublicAccessBlockStub,
           deleteObjects: deleteObjectsStub,
           listBuckets: listBucketsStub,
           listObjectsV2: listObjectsV2Stub


### PR DESCRIPTION
…k applied by S3

deployments to some AWS regions are currently failing owing to a recent AWS change: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ - this change ensures that the public access block is now removed on bucket creation.

fixes #183