### PR TITLE
fix(bucket-utils): small fix for async race condition

### DIFF
--- a/lib/bucket-utils.js
+++ b/lib/bucket-utils.js
@@ -96,7 +96,7 @@ function createBucket(aws, bucketName) {
   };
 
   return aws.request('S3', 'createBucket', params).then(() => {
-    aws.request('S3', 'deletePublicAccessBlock', {
+    return aws.request('S3', 'deletePublicAccessBlock', {
       Bucket: bucketName
     });
   });


### PR DESCRIPTION
ensure that deletePublicAccessBlock is allowed to run before moving on from bucket creation.

Following on from the fix I did a few days ago around the breaking S3 policy change, I missed a return here to ensure that the `deletePublicAccessBlock` call is completed before moving on. We still see occasional errors owing to this race condition.